### PR TITLE
Allow hostname specification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ $ export OPENAI_API_KEY=...
 $ dune test
 res: 枕草子によると、秋は「夕暮れ」です。
 ```
+
+We can also connect to a [llamma.cpp](https://github.com/ggerganov/llama.cpp) local server by changing the client creation to
+
+```ocaml
+let client = Client.create ~secure:false ~host:"localhost" ~port:8080 "nokey" in
+```

--- a/src/client.ml
+++ b/src/client.ml
@@ -4,7 +4,8 @@ type t =
   ; c : Curl.t
   }
 
-let create api_key =
-  let base_url = "https://api.openai.com" in
+let create ?(secure=true) ?(host="api.openai.com") ?port api_key =
+  let base_url = "http" ^ if secure then "s" else "" ^ "://" ^ host in
+  let base_url = match port with None -> base_url | Some port -> base_url ^ ":" ^ string_of_int port in
   { api_key; gen_url = ( ^ ) base_url; c = Ezcurl_lwt.make () }
 ;;


### PR DESCRIPTION
This is useful to be able to connect to llama.cpp servers running locally.